### PR TITLE
Feat(transcription): Move transcription logic to Assistant class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,3 +114,17 @@ updated dependent composer packages
 ### Fixed
 - Fixed create assistant functionality
 - Updated test cases in AiAssistantTest.php
+
+## 2.0.3 - 2025-02-11
+### Changed
+- Move transcription logic to Assistant class
+- Deprecate transcribeTo method in AiAssistant class with warning
+- Add new transcription functionality to Assistant class
+- Implement setFilePath method for better file handling
+- Add robust file handling with error checking
+- Improve code organization and maintainability
+
+The change moves the transcription functionality to a more appropriate
+location while maintaining backward compatibility through a deprecation
+notice. This improves the overall architecture and provides better
+error handling for file operations.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,10 @@ $optionalText = 'An optional text to guide the model's style or continue a previ
 // The language of the input audio. Supplying the input language in ISO-639-1 format will improve accuracy and latency.
 $language = 'en';
 
-$transcription = AiAssistant::acceptPrompt($audioFilePath)->transcribe($language, $optionalText);
+$transcription = AiAssistant::init()
+                ->setFilePath($audioFilePath)
+                ->transcribeTo($language, $optionalText);
+
 
 // The response will be a text format of the audio file
 

--- a/src/AiAssistant.php
+++ b/src/AiAssistant.php
@@ -141,6 +141,8 @@ class AiAssistant implements AiAssistantContract
      */
     public function transcribeTo(string $language, ?string $optionalText = ''): string
     {
+        trigger_error('The transcribeTo method is deprecated. Use the transcribeTo method of the AssistantService client instead.', E_USER_DEPRECATED);
+
         $this->audioToTextGeneratorConfig['file'] = fopen($this->prompt, 'rb');
         if ($optionalText !== '') {
             $this->audioToTextGeneratorConfig['prompt'] = $optionalText;


### PR DESCRIPTION
- Deprecate transcribeTo method in AiAssistant class with warning
- Add new transcription functionality to Assistant class
- Implement setFilePath method for better file handling
- Add robust file handling with error checking
- Improve code organization and maintainability

The change moves the transcription functionality to a more appropriate location while maintaining backward compatibility through a deprecation notice. This improves the overall architecture and provides better error handling for file operations.